### PR TITLE
check for both null AND undefined in stream writer

### DIFF
--- a/src/util/stream/writer.ts
+++ b/src/util/stream/writer.ts
@@ -14,7 +14,7 @@ export default function makeWriter(stm: Writable) {
       stm.write(buf, error => {
         busy = false;
 
-        if (error !== undefined) {
+        if (error !== null && error !== undefined) {
           reject(error);
         } else {
           resolve();


### PR DESCRIPTION
This fixes IDZ support when minime is run using a newer LTS version of node js.
(Streams use null for the error argument now for write and end callbacks)